### PR TITLE
Get the npm test script running on windows and *nix

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,9 +1,9 @@
 require('shelljs/global');
-var tape = './node_modules/tape/bin/tape';
-var tapSpec = './node_modules/tap-spec/bin/cmd.js --color';
+var tape = '"node_modules/.bin/tape"';
+var tapSpec = '"node_modules/.bin/tap-min" --color';
 
 //run tests server-side
-exec(tape + ' \'./test/unit/**/*.test.js\' | ' + tapSpec);
+exec(tape + ' "./test/unit/**/*.test.js" | ' + tapSpec);
 
 //do code-coverage too
 // var nyc = './node_modules/nyc/bin/nyc.js';


### PR DESCRIPTION
Now `npm run test` should just work on windows and linux.