### PR TITLE
Tag using tag arrays and lumping methods + extending tag hierarchy by passing tagset to nlp constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ viz/
 compromise.js.tmproj
 compromise.xcodeproj
 npm-debug.log
+.vscode/
+app.js
+builds/
+legal/

--- a/src/result/build.js
+++ b/src/result/build.js
@@ -23,19 +23,32 @@ const normalizeLex = function(lex) {
 
 const extendTags = function(newTags) {
   console.log(newTags);
-  console.log(tagArr);
+  tagArr.addTags(newTags);
+  console.log(tagArr.allTags());
 };
 
 //build a new pos-tagged Result obj from a string
 const fromString = (str, lexicon, tagSet) => {
   let sentences = tokenize(str);
+
+  //LS 13-03-17: include multiword lexicon entries in lexicon without white spaces or hypens
+  for (var key in lexicon) {
+    var noSpaceOrHypenKey = key.replace(/-|\s|[.]/g,"");
+
+    if(noSpaceOrHypenKey != key)
+    {
+      lexicon[noSpaceOrHypenKey] = lexicon[key];
+    }
+  }
+
+  if (tagSet) {
+    extendTags(tagSet);
+  }
+
   //make sure lexicon obeys standards
   lexicon = normalizeLex(lexicon);
   let list = sentences.map((s) => Terms.fromString(s, lexicon));
   //extend tagset for this ref
-  if (tagSet) {
-    extendTags(tagSet);
-  }
 
   let r = new Text(list, lexicon, null, tagSet);
   //give each ts a ref to the result

--- a/src/result/index.js
+++ b/src/result/index.js
@@ -69,6 +69,7 @@ Text = require('./methods/sort')(Text);
 Text = require('./methods/split')(Text);
 Text = require('./methods/tag')(Text);
 Text = require('./methods/normalize')(Text);
+Text = require('./methods/lump')(Text);
 
 const subset = {
   acronyms: require('./subset/acronyms'),

--- a/src/result/methods/lump.js
+++ b/src/result/methods/lump.js
@@ -7,6 +7,23 @@ const lumpMethods = (Text) => {
     lump: function () {
       this.list.forEach((ts) => { ts.lump(); });
       return this;
+    },
+    
+    lumpIntoParent: function(tags, description)
+    {
+      for(let mI = this.list.length-1; mI >= 0; mI--){
+        let firstTerm = this.list[mI].firstTerm();
+        let lastTerm = this.list[mI].lastTerm();
+
+        this.parent.lumpIntoOne(firstTerm, lastTerm, tags, description);
+
+        // let lumpedTerm = this.list[mI].lump(); 
+        // lumpedTerm.tagAs(tags, description);
+
+        
+      }
+
+      return this.parent;
     }
   };
 

--- a/src/result/methods/lump.js
+++ b/src/result/methods/lump.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const lumpMethods = (Text) => {
+
+  const methods = {
+
+    lump: function () {
+      this.list.forEach((ts) => { ts.lump(); });
+      return this;
+    }
+  };
+
+  //hook them into result.proto
+  Object.keys(methods).forEach((k) => {
+    Text.prototype[k] = methods[k];
+  });
+  return Text;
+};
+
+module.exports = lumpMethods;

--- a/src/tagger/steps/02-lexicon_step.js
+++ b/src/tagger/steps/02-lexicon_step.js
@@ -9,19 +9,21 @@ const log = p.log;
 const path = 'tagger/lexicon';
 
 const check_lexicon = (str, sentence) => {
+  let array = [];
+  
   //check a user's custom lexicon
   let custom = sentence.lexicon || {};
   if (custom[str]) {
-    return custom[str];
+    array.push(custom[str]);
   }
   if (lexicon[str]) {
-    return lexicon[str];
+    array.push(lexicon[str]);
   }
   let tag = tries.lookup(str);
   if (tag) {
-    return tag;
+    array.push(tag);
   }
-  return null;
+  return array.length == 0 ? null : array;
 };
 
 const lexicon_pass = function (ts) {

--- a/src/tags/conflicts.js
+++ b/src/tags/conflicts.js
@@ -5,7 +5,7 @@ const conflicts = [
   //top-level pos are all inconsistent
   ['Noun', 'Verb', 'Adjective', 'Adverb', 'Determiner', 'Conjunction', 'Preposition', 'QuestionWord', 'Expression', 'Url', 'PhoneNumber', 'Email', 'Emoji'],
   //exlusive-nouns
-  ['Person', 'Organization', 'Value', 'Place', 'Actor', 'Demonym', 'Pronoun'],
+  //['Person', 'Organization', 'Value', 'Place', 'Actor', 'Demonym', 'Pronoun'],
   //things that can't be plural
   ['Plural', 'Singular'],
   // ['Plural', 'Pronoun'],
@@ -14,7 +14,7 @@ const conflicts = [
   ['Plural', 'Currency'],
   ['Plural', 'Ordinal'],
   //exlusive-people
-  ['MaleName', 'FemaleName'],
+  //['MaleName', 'FemaleName'],
   ['FirstName', 'LastName', 'Honorific'],
   //adjectives
   ['Comparative', 'Superlative'],

--- a/src/tags/index.js
+++ b/src/tags/index.js
@@ -32,12 +32,19 @@ const all_children = (obj) => {
   });
   return children;
 };
+  
+//make tags
+var all = {};
 
-const build = function() {
-  //make tags
-  let all = {};
-  //recursively add them
-  const add_tags = (obj, is) => {
+const addTags = function (obj, is) {
+    
+    if(is==undefined) is = [];
+
+    if(Object.keys(all).length === 0 && all.constructor === Object && obj != tree)
+    {
+      build();
+    }
+
     Object.keys(obj).forEach((k) => {
       is = is.slice(0); //clone it
       all[k] = {
@@ -45,11 +52,15 @@ const build = function() {
         children: all_children(obj[k])
       };
       if (obj[k] !== true) {
-        add_tags(obj[k], is.concat([k])); //recursive
+        addTags(obj[k], is.concat([k])); //recursive
       }
     });
   };
-  add_tags(tree, []);
+
+const build = function() {
+
+  //recursively add them
+  addTags(tree);
 
   //add extras
   Object.keys(all).forEach((tag) => {
@@ -68,7 +79,19 @@ const build = function() {
     }
   });
 
+  //addTags({ParentLegal:{ Legal: true}});
+
   return all;
 };
 
-module.exports = build();
+const allTags = function() {
+
+  if(Object.keys(all).length === 0 && all.constructor === Object)
+  {
+    build();
+  }
+
+  return all;
+};
+
+module.exports = {addTags, allTags};

--- a/src/term/methods/tag/index.js
+++ b/src/term/methods/tag/index.js
@@ -19,7 +19,7 @@ const addMethods = (Term) => {
     canBe: function (tag) {
       tag = tag || '';
       tag = tag.replace(/^#/, '');
-      let not = tagset[tag].not || [];
+      let not = tagset.allTags()[tag].not || [];
       for (let i = 0; i < not.length; i++) {
         if (this.tag[not[i]]) {
           return false;

--- a/src/term/methods/tag/setTag.js
+++ b/src/term/methods/tag/setTag.js
@@ -7,11 +7,11 @@ const unTag = require('./unTag');
 
 
 const makeCompatible = (term, tag, reason) => {
-  if (!tagset[tag]) {
+  if (!tagset.allTags()[tag]) {
     return;
   }
   //find incompatible tags
-  let not = tagset[tag].not || [];
+  let not = tagset.allTags()[tag].not || [];
   for (let i = 0; i < not.length; i++) {
     unTag(term, not[i], reason);
   }
@@ -49,8 +49,8 @@ const tagAll = function (term, tag, reason) {
   tag = tag.replace(/^#/, '');
   tag_one(term, tag, reason);
   //find assumed-tags
-  if (tagset[tag]) {
-    let tags = tagset[tag].parents || [];
+  if (tagset.allTags()[tag]) {
+    let tags = tagset.allTags()[tag].parents || [];
     for (let i = 0; i < tags.length; i++) {
       tag_one(term, tags[i], '-');
     }

--- a/src/term/methods/tag/setTag.js
+++ b/src/term/methods/tag/setTag.js
@@ -33,6 +33,16 @@ const tag_one = (term, tag, reason) => {
 const tagAll = function (term, tag, reason) {
   if (!term || !tag || typeof tag !== 'string') {
     // console.log(tag)
+    
+    //LS 13-03-17 if tag is an array - call this recursively for each entry...
+    if(!!tag && tag.constructor === Array)
+    {
+      for (let i = 0; i < tag.length; i++)
+      {
+          tagAll(term, tag[i], reason);
+      }
+    }
+
     return;
   }
   tag = tag || '';

--- a/src/term/methods/tag/unTag.js
+++ b/src/term/methods/tag/unTag.js
@@ -17,15 +17,15 @@ const unTagAll = (term, tag, reason) => {
     return;
   }
   unTagOne(term, tag, reason);
-  if (tagset[tag]) {
+  if (tagset.allTags()[tag]) {
     //pull-out their children (dependants) too
     //this should probably be recursive, instead of just 2-deep
-    let killAlso = tagset[tag].children || [];
+    let killAlso = tagset.allTags()[tag].children || [];
     for (let o = 0; o < killAlso.length; o++) {
       //kill its child
       unTagOne(term, killAlso[o], reason);
       //kill grandchildren too
-      let kill2 = tagset[killAlso[o]].children || []
+      let kill2 = tagset.allTags()[killAlso[o]].children || []
       for (let i2 = 0; i2 < kill2.length; i2++) {
         unTagOne(term, kill2[i2], reason);
       }

--- a/src/terms/index.js
+++ b/src/terms/index.js
@@ -102,4 +102,5 @@ Terms = require('./methods/out')(Terms);
 Terms = require('./methods/replace')(Terms);
 Terms = require('./methods/split')(Terms);
 Terms = require('./methods/transform')(Terms);
+Terms = require('./methods/lump')(Terms);
 module.exports = Terms;

--- a/src/terms/methods/lump.js
+++ b/src/terms/methods/lump.js
@@ -1,0 +1,26 @@
+'use strict';
+const combine = require('../../tagger/lumper/combine');
+
+const lumpMethods = (Terms) => {
+
+  const methods = {
+
+    lump: function () {
+      //for (let t = 0; t <= this.terms.length; t++) {
+      while(this.terms.length>1)
+      {
+        combine(this, 0);
+      }
+
+      return this;
+    }
+  };
+
+  //hook them into result.proto
+  Object.keys(methods).forEach((k) => {
+    Terms.prototype[k] = methods[k];
+  });
+  return Terms;
+};
+
+module.exports = lumpMethods;

--- a/src/terms/methods/lump.js
+++ b/src/terms/methods/lump.js
@@ -14,9 +14,17 @@ const lumpMethods = (Terms) => {
       return this;
     },
     lumpIntoOne: function(startTerm, endTerm, tag, tagReason){
+       
+       if(startTerm==endTerm)
+       {
+          startTerm.tagAs(tag, tagReason);
+          return startTerm;         
+       }
+
        let terms = startTerm.parentTerms;
        let endTermIndex = endTerm.index();
        let startTermIndex = startTerm.index(); 
+       
         for(let i = endTermIndex -1; i>=startTermIndex; i--){
            combine(terms, i);
         }

--- a/src/terms/methods/lump.js
+++ b/src/terms/methods/lump.js
@@ -6,13 +6,24 @@ const lumpMethods = (Terms) => {
   const methods = {
 
     lump: function () {
-      //for (let t = 0; t <= this.terms.length; t++) {
       while(this.terms.length>1)
       {
         combine(this, 0);
       }
 
       return this;
+    },
+    lumpIntoOne: function(startTerm, endTerm, tag, tagReason){
+       let terms = startTerm.parentTerms;
+       let endTermIndex = endTerm.index();
+       let startTermIndex = startTerm.index(); 
+        for(let i = endTermIndex -1; i>=startTermIndex; i--){
+           combine(terms, i);
+        }
+
+        terms.terms[startTermIndex].tagAs(tag, tagReason);
+
+        return terms;
     }
   };
 


### PR DESCRIPTION
- Allow tags array to be passed to tag methods
- Added some lumping methods - this is how i use it: ts.match('#Noun #Verb').lumpIntoParent(['myTag1', 'myTag2'], 'reason i am tagging it...');
- Added a way to extend tagset hierarchy... ie.
nlp("My text to parse", myLexicon, {LegalParent :{ Legal: true}});
- Relaxed tag conflicts - some names can be both Male and Female and these are not conflicting - 'Person', 'Organization', 'Value', 'Place', 'Actor', 'Demonym', 'Pronoun'
-All unit tests pass now

