### PR TITLE
Add percent as a unit

### DIFF
--- a/src/data/values/units.js
+++ b/src/data/values/units.js
@@ -136,6 +136,9 @@ const units = {
     'picosecond': 'picosecond',
     'femtosecond': 'femtosecond',
     'attosecond': 'attosecond'
+  },
+  'Misc': {
+    '%': 'percent'
   }
 };
 


### PR DESCRIPTION
Numbers like `12%` aren't picked up by the values extraction. I'll be honest I'm really not sure what type of unit that should be so I just thought `Misc` for now to be pragmatic. You may have a better idea for naming though.