### PR TITLE
QuestionWord and EndPunctuation fix

### DIFF
--- a/src/tagger/corrections/index.js
+++ b/src/tagger/corrections/index.js
@@ -112,7 +112,12 @@ const corrections = function(ts) {
     //is eager to go
     ts.match('#Copula #Adjective to #Verb').match('#Adjective to').tag('Verb', 'correction');
     //the word 'how'
-    ts.match('how (#Copula|#Modal|#PastTense)').term(0).tag('QuestionWord', 'how-question');
+    !!ts.match('^how').term(0).tag('QuestionWord', 'how-question') ||
+    ts.match('how (#Determiner|#Copula|#Modal|#PastTense)').term(0).tag('QuestionWord', 'how-question');
+    //the word 'which'
+    !!ts.match('^which').term(0).tag('QuestionWord', 'which-question') ||
+    !ts.match('which . (#Noun)+ #Pronoun').found() &&
+    ts.match('which').term(0).tag('QuestionWord', 'which-question');
     //is mark hughes
     ts.match('#Copula #Infinitive #Noun').term(1).tag('Noun', 'is-pres-noun');
 

--- a/src/term/methods/punctuation.js
+++ b/src/term/methods/punctuation.js
@@ -1,5 +1,5 @@
 'use strict';
-const endPunct = /([a-z])([,:;\/.(\.\.\.)\!\?]+)$/i;
+const endPunct = /([^\/,:;.()!?]{0,1})([\/,:;.()!?]+)$/i;
 const addMethods = (Term) => {
 
   const methods = {
@@ -16,12 +16,13 @@ const addMethods = (Term) => {
           '!': 'exclamation',
           '?': 'question'
         };
-        if (allowed[m[2]] !== undefined) {
+        if (!!allowed[m[2]]) {
           return m[2];
         }
       }
       return null;
     },
+
     setPunctuation: function(punct) {
       this.killPunctuation();
       this.text += punct;
@@ -30,7 +31,7 @@ const addMethods = (Term) => {
 
     /** check if the term ends with a comma */
     hasComma: function () {
-      if (this.endPunctuation() === 'comma') {
+      if (this.endPunctuation() === ',') {
         return true;
       }
       return false;


### PR DESCRIPTION
_QuestionWord_
 The words `how` and `which` are fairly often `QuestionWord`, also when
used for indirect questions.
As described in https://github.com/nlp-compromise/compromise/issues/399

_EndPunctuation_
EndPunctuation fixes for spaces, consecutive pointings and combinations
as described in https://github.com/nlp-compromise/compromise/issues/397

- tested fix, all available tests passed