### PR TITLE
Make it easier for Typescript to load types

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "natural language processing in the browser",
   "version": "11.2.1",
   "main": "./builds/compromise.js",
+  "types": "./compromise.d.ts",
   "repository": {
     "type": "git",
     "url": "git://github.com/nlp-compromise/compromise.git"


### PR DESCRIPTION
Related to #254; this quick change lets Typescript load the current "tentative" types file during node module resolution.